### PR TITLE
Added /status endpoint for healthcheck

### DIFF
--- a/src/routes/status_route.js
+++ b/src/routes/status_route.js
@@ -1,0 +1,12 @@
+'use strict'
+
+module.exports = [{
+  method: 'GET',
+  path: '/status',
+  config: {
+    description: 'Heathcheck status',
+    handler: function (request, reply, source, errors) {
+      reply({ status: "ok"}).code(200)
+    }
+  }
+}]


### PR DESCRIPTION
Added `/status` endpoint for automated health check. Response to `GET` will always be `{ status: "ok" }` with HTTP status code 200.